### PR TITLE
check for allowed log levels directly in transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ npm install cplus
 
     ![Console Output](docs/images/console-output.png)
 
-- Allows log level limit (option: `logLevel`).
+- Allows log level limit (option: `logLevel`). NOTE: This will only work with
+  built-in transports. So if you override it with your own transport (using `transport` option),
+  you have to handle the logic in there.
 
    ```javascript
    // Only display log levels `warn` and more severe (`error`, `fatal`).
@@ -68,6 +70,26 @@ npm install cplus
 
 - If you want to access built-in transports directly, you can do that. Just import `transports` object
   that contains `BrowserTransport` and `CliTransport` constructors.
+
+- If you need to switch from built-in transport for `Logger` (perhaps after initialization or right after installing `cplus`), you can do so by calling `setTransport`:
+
+```javascript
+  import cplus from 'cplus'
+
+  cplus.install({
+    untouchedLogLevels: [ cplus.LogLevels.ERROR, cplus.LogLevels.TRACE ],
+  })
+
+  // after the installation phase, instance of logger will be avaible in browser
+  // like this
+  const logger = window.console.logger
+
+  // create your own instance of custom transport
+  const customTransport = new CustomTransport()
+
+  // switch from built-in transport to your custom one
+  logger.setTransport(customTransport)
+```
 
 ## Usage
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -8,30 +8,30 @@ Logger = require './logger'
 
 { getGlobalScope, isBrowser } = require './utils'
 
-createBrowserTransport = ->
+createBrowserTransport = (options) ->
   globalScope = getGlobalScope()
-  transport = new BrowserTransport(globalScope.console)
+  transport = new BrowserTransport(globalScope.console, options)
   transport.setLogLevelPrefixes(prefixes.browser)
   transport.setLogLevelStyles(colors.browser)
 
   return transport
 
-createCliTransport = ->
+createCliTransport = (options) ->
   globalScope = getGlobalScope()
-  transport = new CliTransport(globalScope.process.stderr)
+  transport = new CliTransport(globalScope.process.stderr, options)
   transport.setLogLevelPrefixes(prefixes.cli)
   transport.setLogLevelColors(colors.cli)
 
   return transport
 
-createTransport = ->
+createTransport = (options) ->
   globalScope = getGlobalScope()
   browser = isBrowser(globalScope)
 
   if browser
-    return createBrowserTransport()
+    return createBrowserTransport(options)
 
-  return createCliTransport()
+  return createCliTransport(options)
 
 
 module.exports =
@@ -49,7 +49,7 @@ module.exports =
 
   create: (options = {}) ->
     globalScope = getGlobalScope()
-    transport = options.transport or createTransport() 
+    transport = options.transport or createTransport(options) 
 
     logger = new Logger(transport, options)
     nextConsole = logger.extendConsole(globalScope.console)

--- a/src/logger.coffee
+++ b/src/logger.coffee
@@ -6,11 +6,7 @@ LogLevels = require './log-levels'
 class Logger extends EventEmitter
   constructor: (transport = null, options = {}) ->
     @_transport = transport
-    @_levelLimit = options.logLevel or LogLevels.SILLY
     @_untouchedLevels = options.untouchedLogLevels or []
-
-  setLevelLimit: (logLevel) ->
-    @_levelLimit = logLevel
 
   extendConsole: (console) ->
     # NOTE: Always start with the native/initial console.
@@ -56,9 +52,6 @@ class Logger extends EventEmitter
       logLevel,
       args
     })
-
-    if logLevel > @_levelLimit
-      return
 
     @_transport?.logMessage(logLevel, args...)
 

--- a/src/transports/browser-transport.coffee
+++ b/src/transports/browser-transport.coffee
@@ -2,7 +2,7 @@ LogLevels = require '../log-levels'
 
 
 class BrowserTransport
-  constructor: (console) ->
+  constructor: (console, options = {}) ->
     @_console = console
 
     @_prefixStyle = 'color: #C0C0C0; border-right: 1px solid #D0D0D0; padding-left: 3px'
@@ -11,6 +11,7 @@ class BrowserTransport
 
     @_styles = {}
     @_defaultStyle = 'color: #000'
+    @_levelLimit = options.logLevel or LogLevels.SILLY
 
   setLogLevelPrefixes: (prefixes) ->
     @_prefixes = prefixes or {}
@@ -24,7 +25,13 @@ class BrowserTransport
   setDefaultStyle: (defaultStyle) ->
     @_defaultStyle = defaultStyle or ''
 
+  setLevelLimit: (logLevel) ->
+    @_levelLimit = logLevel
+
   logMessage: (logLevel, args...) ->
+    if logLevel > @_levelLimit
+      return
+
     if typeof args[0] != 'object'
       message = args[0]
       args = args.slice(1)

--- a/src/transports/cli-transport.coffee
+++ b/src/transports/cli-transport.coffee
@@ -1,9 +1,10 @@
 colorize = require 'colorize-str'
 util = require 'util'
+LogLevels = require '../log-levels'
 
 
 class CliTransport
-  constructor: (outputStream) ->
+  constructor: (outputStream, options = {}) ->
     @_outputStream = outputStream
 
     @_prefixColor = '#2D2D2D'
@@ -12,6 +13,8 @@ class CliTransport
 
     @_colors = {}
     @_defaultColor = '#FFF'
+
+    @_levelLimit = options.logLevel or LogLevels.SILLY
 
   setLogLevelPrefixes: (prefixes) ->
     @_prefixes = prefixes or {}
@@ -25,7 +28,13 @@ class CliTransport
   setDefaultColor: (defaultColor) ->
     @_defaultColor = defaultColor or ''
 
+  setLevelLimit: (logLevel) ->
+    @_levelLimit = logLevel
+
   logMessage: (logLevel, args...) ->
+    if logLevel > @_levelLimit
+      return
+
     message = util.format(args...)
     prefix = @_getLogLevelPrefix(logLevel)
     color = @_getMessageColor(logLevel)


### PR DESCRIPTION
Now the check for whether the output should be displayed in console by `logLevel` options is handled in `logMessage` method in a transport instance.

This makes it better for usage with custom transports which might want to access any log level, add some custom logic and then perhaps later filter the logs.

I also updated documentation for `setTransport` method on `Logger` class because last time we added that. Also docs for `logLevel` option  mentions what this change means.